### PR TITLE
specify name attribute for each heading

### DIFF
--- a/bin/transcribe
+++ b/bin/transcribe
@@ -10,16 +10,25 @@ var R = require('ramda');
 var pkg = require('../package.json');
 
 
+//. esc :: String -> String
+var esc = R.pipe(R.replace(/&/g, '&amp;'),
+                 R.replace(/</g, '&lt;'),
+                 R.replace(/"/g, '&quot;'));
+
+
 //. formatSignature :: Options -> String -> Number -> String -> String
 var formatSignature = R.curry(function(options, filename, line, signature) {
-  return R.join('', [
-    options.heading,
-    ' [`',
-    signature,
-    '`](',
-    options.url.replace('{filename}', filename).replace('{line}', line),
-    ')\n',
-  ]);
+  var tagName = 'h' + String(options.heading.length);
+  var href = options.url
+             .replace('{filename}', filename)
+             .replace('{line}', line);
+  return (
+    '<' + esc(tagName) + ' name="' + esc(signature.split(' :: ')[0]) + '">' +
+      '<code>' +
+        '<a href="' + esc(href) + '">' + esc(signature) + '</a>' +
+      '</code>' +
+    '</' + esc(tagName) + '>\n'
+  );
 });
 
 


### PR DESCRIPTION
The `name` attribute GitHub generates from a heading is messy when the heading contains punctuation. `map :: (a -> b) -> [a] -> [b]`, for example, becomes `map--a---b---a---b`. I'm not aware of a way to override GitHub's default behaviour, but it is possible to specify *another* `name` attribute. One can then use `https://github.com/xxx/yyy#map` rather than `https://github.com/xxx/yyy#map--a---b---a---b` when linking to a particular function's documentation.
