### PR TITLE
add --heading-prefix option to lift restriction on use of " :: "

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -30,7 +30,6 @@
   "requireSpaceBetweenArguments": true,
   "requireSpacesInConditionalExpression": true,
   "requireSpacesInFunction": {"beforeOpeningCurlyBrace": true},
-  "requireTrailingComma": {"ignoreSingleLine": true},
   "validateLineBreaks": "LF",
   "validateQuoteMarks": {"escape": true, "mark": "'"}
 }

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ Transcribe is a simple program which generates Markdown documentation from code
 comments.
 
 The general idea is that each "export" should be accompanied by a "docstring".
-The first line of the "docstring" should be a Haskell-inspired type signature.
-The signature line is identified by `::`, which must have a space either side.
+The first line of the "docstring" should be a Haskell-inspired type signature
+in the form `<heading-prefix> <name> :: <type>`.
 
 ```javascript
-//. map :: (a -> b) -> [a] -> [b]
+//# map :: (a -> b) -> [a] -> [b]
 //.
 //. Transforms a list of elements of type `a` into a list of elements
 //. of type `b` using the provided function of type `a -> b`.
@@ -28,9 +28,17 @@ var map = function(f) {
 };
 ```
 
-The `--prefix` option specifies which lines in the source files should appear
-in the output. The default value is `//.`; specify a different value if using
-a different comment style. For example:
+The __`--heading-prefix`__ option specifies which lines in the source files
+contain type signatures to become headings in the output. The default value
+is `//#`; specify a different value if using a different comment style. For
+example:
+
+    --heading-prefix '#%'
+
+The __`--prefix`__ option specifies which lines in the source files should
+appear in the output along with the lines prefixed with `<heading-prefix>`.
+The default value is `//.`; specify a different value if using a different
+comment style. For example:
 
     --prefix '#.'
 
@@ -40,21 +48,21 @@ in the default prefix makes it possible to be selective about which comments
 are included in the output: comments such as `// Should never get here!` will
 be ignored.
 
-The `--url` option specifies a template for generating links to specific lines
-of source code on GitHub or another code-hosting site. The value should include
-`{filename}` and `{line}` placeholders to be replaced with the filename and
-line number of each of the signature lines. For example:
+The __`--url`__ option specifies a template for generating links to specific
+lines of source code on GitHub or another code-hosting site. The value should
+include `{filename}` and `{line}` placeholders to be replaced with the filename
+and line number of each of the signature lines. For example:
 
     --url 'https://github.com/plaid/sanctuary/blob/v0.4.0/{filename}#L{line}'
 
 Avoid pointing to a moving target: include a tag name or commit hash rather
 than a branch name such as `master`.
 
-The `--heading` option specifies the heading level. The default value is `###`,
-which corresponds to an `<h3>` element in HTML. Remember to quote the value if
-providing this option, since `#` begins a line comment in Bash. For example:
+The __`--heading-level`__ option specifies the heading level, an integer in
+range [1, 6]. The default value is `3`, which corresponds to an `<h3>` element
+in HTML. Specify a different value if desired. For example:
 
-    --heading '####'
+    --heading-level 4
 
 The options should be followed by one or more filenames. The filenames may
 be separated from the options by `--`. Files are processed in the order in
@@ -65,7 +73,7 @@ Here's a complete example:
     $ transcribe \
     >   --url 'https://github.com/plaid/example/blob/v1.2.3/{filename}#L{line}' \
     >   -- examples/fp.js
-    ### [`map :: (a -> b) -> [a] -> [b]`](https://github.com/plaid/example/blob/v1.2.3/examples/fp.js#L4)
+    <h3 name="map"><code><a href="https://github.com/plaid/example/blob/v1.2.3/examples/fp.js#L4">map :: (a -> b) -> [a] -> [b]</a></code></h3>
 
     Transforms a list of elements of type `a` into a list of elements
     of type `b` using the provided function of type `a -> b`.
@@ -75,7 +83,7 @@ Here's a complete example:
     ['1', '2', '3', '4', '5']
     ```
 
-    ### [`filter :: (a -> Boolean) -> [a] -> [a]`](https://github.com/plaid/example/blob/v1.2.3/examples/fp.js#L24)
+    <h3 name="filter"><code><a href="https://github.com/plaid/example/blob/v1.2.3/examples/fp.js#L24">filter :: (a -> Boolean) -> [a] -> [a]</a></code></h3>
 
     Returns the list of elements which satisfy the provided predicate.
 

--- a/bin/transcribe
+++ b/bin/transcribe
@@ -18,7 +18,7 @@ var esc = R.pipe(R.replace(/&/g, '&amp;'),
 
 //. formatSignature :: Options -> String -> Number -> String -> String
 var formatSignature = R.curry(function(options, filename, line, signature) {
-  var tagName = 'h' + String(options.heading.length);
+  var tagName = 'h' + String(options.headingLevel);
   var href = options.url
              .replace('{filename}', filename)
              .replace('{line}', line);
@@ -36,14 +36,16 @@ var formatSignature = R.curry(function(options, filename, line, signature) {
 var parseLine = R.curry(function(options, filename, line, value) {
   return R.pipe(
     R.replace(/^\s+/, ''),
-    R.ifElse(R.pipe(R.substringTo(R.length(options.prefix)),
-                    R.eq(options.prefix)),
-             R.pipe(R.substringFrom(R.length(options.prefix)),
-                    R.replace(/^[ ]/, ''),
-                    R.ifElse(R.test(/ :: /),
-                             formatSignature(options, filename, line),
-                             R.concat(R.__, '\n'))),
-             R.always('\n'))
+    R.cond([R.pipe(R.strIndexOf(options.headingPrefix), R.eq(0)),
+            R.pipe(R.substringFrom(R.length(options.headingPrefix)),
+                   R.replace(/^[ ]/, ''),
+                   formatSignature(options, filename, line))],
+           [R.pipe(R.strIndexOf(options.prefix), R.eq(0)),
+            R.pipe(R.substringFrom(R.length(options.prefix)),
+                   R.replace(/^[ ]/, ''),
+                   R.concat(R.__, '\n'))],
+           [R.T,
+            R.always('\n')])
   )(value);
 });
 
@@ -79,21 +81,34 @@ program
 .version(pkg.version)
 .usage('[options] <file ...>')
 .description(pkg.description)
-.option('--heading <string>', 'heading level (default: "###")')
-.option('--prefix <string>', 'prefix for lines to transcribe (default: "//.")')
-.option('--url <string>', 'source URL with {filename} and {line} placeholders')
+.option('--heading-level <num>', 'heading level in range [1, 6] (default: 3)')
+.option('--heading-prefix <str>', 'prefix for heading lines (default: "//#")')
+.option('--prefix <str>', 'prefix for non-heading lines (default: "//.")')
+.option('--url <str>', 'source URL with {filename} and {line} placeholders')
 .parse(process.argv);
+
+var valid = true;
+
+if (!(program.headingLevel == null || /^[1-6]$/.test(program.headingLevel))) {
+  process.stderr.write('Invalid --heading-level\n');
+  valid = false;
+}
 
 if (program.url == null) {
   process.stderr.write('No --url template specified\n');
+  valid = false;
+}
+
+if (!valid) {
   process.exit(1);
 }
 
-//. options :: { heading :: String, prefix :: String, url :: String }
+//. options :: { headingLevel, headingPrefix, prefix, url }
 var options = {
-  heading:  R.defaultTo('###', program.heading),
-  prefix:   R.defaultTo('//.', program.prefix),
-  url:      program.url,
+  headingLevel:   Number(R.defaultTo('3', program.headingLevel)),
+  headingPrefix:  R.defaultTo('//#', program.headingPrefix),
+  prefix:         R.defaultTo('//.', program.prefix),
+  url:            program.url,
 };
 
 process.stdout.write(transcribe(options, program.args));

--- a/examples/fp.js
+++ b/examples/fp.js
@@ -1,7 +1,7 @@
 'use strict';
 
 
-//. map :: (a -> b) -> [a] -> [b]
+//# map :: (a -> b) -> [a] -> [b]
 //.
 //. Transforms a list of elements of type `a` into a list of elements
 //. of type `b` using the provided function of type `a -> b`.
@@ -21,7 +21,7 @@ var map = function(f) {
 };
 
 
-//. filter :: (a -> Boolean) -> [a] -> [a]
+//# filter :: (a -> Boolean) -> [a] -> [a]
 //.
 //. Returns the list of elements which satisfy the provided predicate.
 //.


### PR DESCRIPTION
It would be nice to be able to use `::` freely within docstrings, to include type descriptions. For example:

```javascript
//. A Plaid category has the following type:
//.
//. ```haskell
//. Category :: { id :: String
//.             , group :: String
//.             , hierarchy :: [String] }
//. ```
```

This is problematic, though, since each line prefixed with `<prefix>` and containing `::` becomes a heading in the output.

This pull request introduces a __`--heading-prefix`__ option. The `<heading-prefix>` should be used in place of `<prefix>` for each signature line.

To avoid confusion, this pull request also replaces the __`--heading`__ option with a __`--heading-level`__ option. `--heading-level 4` is equivalent to the defunct `--heading '####'`.
