### PR TITLE
control wrapping of type signatures

### DIFF
--- a/bin/transcribe
+++ b/bin/transcribe
@@ -16,6 +16,27 @@ var esc = R.pipe(R.replace(/&/g, '&amp;'),
                  R.replace(/"/g, '&quot;'));
 
 
+//. nbsp :: String -> String
+var nbsp = R.replace(/[ ]/g, '\u00A0');
+
+
+//. controlWrapping :: String -> String
+var controlWrapping =
+R.pipe(R.split(' :: '),
+       R.map(R.split(' => ')),
+       R.map(R.map(R.split(/([(][^()]+[)])/))),
+       R.map(R.map(R.append(''))),
+       R.map(R.map(R.splitEvery(2))),
+       R.map(R.map(R.map(R.over(R.lensIndex(1), nbsp)))),
+       R.map(R.map(R.unnest)),
+       R.map(R.map(R.map(R.split(' -> ')))),
+       R.map(R.map(R.map(R.map(nbsp)))),
+       R.map(R.map(R.map(R.join(' -> ')))),
+       R.map(R.map(R.join(''))),
+       R.map(R.join(' => ')),
+       R.join(' :: '));
+
+
 //. formatSignature :: Options -> String -> Number -> String -> String
 var formatSignature = R.curry(function(options, filename, line, signature) {
   var tagName = 'h' + String(options.headingLevel);
@@ -25,7 +46,9 @@ var formatSignature = R.curry(function(options, filename, line, signature) {
   return (
     '<' + esc(tagName) + ' name="' + esc(signature.split(' :: ')[0]) + '">' +
       '<code>' +
-        '<a href="' + esc(href) + '">' + esc(signature) + '</a>' +
+        '<a href="' + esc(href) + '">' +
+          esc(controlWrapping(signature)) +
+        '</a>' +
       '</code>' +
     '</' + esc(tagName) + '>\n'
   );

--- a/examples/fp.md
+++ b/examples/fp.md
@@ -1,4 +1,4 @@
-<h3 name="map"><code><a href="https://github.com/plaid/transcribe/blob/v0.3.0/examples/fp.js#L4">map :: (a -> b) -> [a] -> [b]</a></code></h3>
+<h3 name="map"><code><a href="https://github.com/plaid/transcribe/blob/v0.3.0/examples/fp.js#L4">map :: (a -> b) -> [a] -> [b]</a></code></h3>
 
 Transforms a list of elements of type `a` into a list of elements
 of type `b` using the provided function of type `a -> b`.
@@ -8,7 +8,7 @@ of type `b` using the provided function of type `a -> b`.
 ['1', '2', '3', '4', '5']
 ```
 
-<h3 name="filter"><code><a href="https://github.com/plaid/transcribe/blob/v0.3.0/examples/fp.js#L24">filter :: (a -> Boolean) -> [a] -> [a]</a></code></h3>
+<h3 name="filter"><code><a href="https://github.com/plaid/transcribe/blob/v0.3.0/examples/fp.js#L24">filter :: (a -> Boolean) -> [a] -> [a]</a></code></h3>
 
 Returns the list of elements which satisfy the provided predicate.
 


### PR DESCRIPTION
Signatures are best wrapped before or after:

  - the `::` following the name;
  - the `=>` following the type-class constraints; or
  - a `->` separating argument types.

This wrapping is undesirable:

    get :: Accessible a => TypeRep b -> String -> a -> Maybe
    b

This wrapping is preferable:

    get :: Accessible a => TypeRep b -> String -> a ->
    Maybe b

To achieve the desired wrapping we replace SPACE with NO-BREAK SPACE in positions where wrapping should not occur. For example:

    get :: Accessible_a => TypeRep_b -> String -> a ->
    Maybe_b

Underscores represent U+00A0 in the example above.

I'd :heart: a review from @benperez. I believe `controlWrapping` to be `:ram:`worthy, though I'd appreciate a review of the logic as this project lacks tests.
