### PR TITLE
Ensure function arrows never break

### DIFF
--- a/bin/transcribe
+++ b/bin/transcribe
@@ -34,7 +34,8 @@ R.pipe(R.split(' :: '),
        R.map(R.map(R.map(R.join(' -> ')))),
        R.map(R.map(R.join(''))),
        R.map(R.join(' => ')),
-       R.join(' :: '));
+       R.join(' :: '),
+       R.replace(/->/g, '-\u2060>'));
 
 
 //. formatSignature :: Options -> String -> Number -> String -> String

--- a/examples/fp.md
+++ b/examples/fp.md
@@ -1,4 +1,4 @@
-<h3 name="map"><code><a href="https://github.com/plaid/transcribe/blob/v0.5.0/examples/fp.js#L4">map :: (a -> b) -> [a] -> [b]</a></code></h3>
+<h3 name="map"><code><a href="https://github.com/plaid/transcribe/blob/v0.5.0/examples/fp.js#L4">map :: (a -⁠> b) -⁠> [a] -⁠> [b]</a></code></h3>
 
 Transforms a list of elements of type `a` into a list of elements
 of type `b` using the provided function of type `a -> b`.
@@ -8,7 +8,7 @@ of type `b` using the provided function of type `a -> b`.
 ['1', '2', '3', '4', '5']
 ```
 
-<h3 name="filter"><code><a href="https://github.com/plaid/transcribe/blob/v0.5.0/examples/fp.js#L24">filter :: (a -> Boolean) -> [a] -> [a]</a></code></h3>
+<h3 name="filter"><code><a href="https://github.com/plaid/transcribe/blob/v0.5.0/examples/fp.js#L24">filter :: (a -⁠> Boolean) -⁠> [a] -⁠> [a]</a></code></h3>
 
 Returns the list of elements which satisfy the provided predicate.
 


### PR DESCRIPTION
Function arrows should be generated with [word joiners](https://en.wikipedia.org/wiki/Word_joiner) so that they are not affected by line wrapping.