### PR TITLE
Generating markdown headers instead of HTML

### DIFF
--- a/bin/transcribe
+++ b/bin/transcribe
@@ -40,19 +40,12 @@ R.pipe(R.split(' :: '),
 
 //. formatSignature :: Options -> String -> Number -> String -> String
 var formatSignature = R.curry(function(options, filename, line, signature) {
-  var tagName = 'h' + String(options.headingLevel);
-  var href = options.url
-             .replace('{filename}', filename)
-             .replace('{line}', line);
-  return (
-    '<' + esc(tagName) + ' name="' + esc(signature.split(' :: ')[0]) + '">' +
-      '<code>' +
-        '<a href="' + esc(href) + '">' +
-          esc(controlWrapping(signature)) +
-        '</a>' +
-      '</code>' +
-    '</' + esc(tagName) + '>\n'
-  );
+  return '######'.slice(0, options.headingLevel) + ' ' +
+         '<a name="' + esc(signature.split(' :: ')[0]) + '"' +
+           ' href="' + esc(options.url.replace('{filename}', filename)
+                                      .replace('{line}', line)) + '">' +
+           '`' + esc(controlWrapping(signature)) + '`' +
+         '</a>\n';
 });
 
 

--- a/examples/fp.md
+++ b/examples/fp.md
@@ -1,4 +1,4 @@
-<h3 name="map"><code><a href="https://github.com/plaid/transcribe/blob/v1.0.0/examples/fp.js#L4">map :: (a -⁠> b) -⁠> [a] -⁠> [b]</a></code></h3>
+### <a name="map" href="https://github.com/plaid/transcribe/blob/v1.0.0/examples/fp.js#L4">`map :: (a -⁠> b) -⁠> [a] -⁠> [b]`</a>
 
 Transforms a list of elements of type `a` into a list of elements
 of type `b` using the provided function of type `a -> b`.
@@ -8,7 +8,7 @@ of type `b` using the provided function of type `a -> b`.
 ['1', '2', '3', '4', '5']
 ```
 
-<h3 name="filter"><code><a href="https://github.com/plaid/transcribe/blob/v1.0.0/examples/fp.js#L24">filter :: (a -⁠> Boolean) -⁠> [a] -⁠> [a]</a></code></h3>
+### <a name="filter" href="https://github.com/plaid/transcribe/blob/v1.0.0/examples/fp.js#L24">`filter :: (a -⁠> Boolean) -⁠> [a] -⁠> [a]`</a>
 
 Returns the list of elements which satisfy the provided predicate.
 


### PR DESCRIPTION
This makes the output more idiomatically Markdown-y, and in particular works better with Markdown-parsing tools like [markdown-toc](https://github.com/jonschlinkert/markdown-toc)